### PR TITLE
Fixes #338: Explore approach to adding stops to the database (Patsaouras - LA Metro Bus Conflation)

### DIFF
--- a/stops.csv
+++ b/stops.csv
@@ -1,1 +1,2 @@
 id;name;description;latitude;longitude;referenced_stops
+mdb_stop_34_055394_N_118_233118_E;Patsaouras Transit Plaza;Patsaouras Transit Plaza;34.055394;-118.233118;[{'stop_id': '30000', 'dataset_id': 'Q22414', 'source_id': 'Q939'}]


### PR DESCRIPTION
**Summary:**

Fixes [#338](https://github.com/MobilityData/mobility-database-interface/issues/338): Explore approach to adding stops to the database (Patsaouras - LA Metro Bus Conflation)

This PR demonstrates what a LA Metro user (developer) would submit to add new MDB Stops to reference their Source Stops for the Patsaouras Transit Plaza use case.

[Original scenario](https://docs.google.com/document/d/1ffvopKK3R2ckmwUWXtmCG93YSQOiTfO307a-hK798RE/edit#):
> (a) I’m LADOT and see **a shared stop ID that references LA Metro’s stop 30000**. I think LA Metro’s stop is the same as my stop 432147. How do I represent them as the same place?

Here, the LA Metro Bus stop for the Patsaouras Transit Plaza has been conflated with the MDB Stops. This would be done by a developer at LA Metro. This will allow a LADOT user to conflate their Source Stops and solve the use case.

To do this, the user can conflate their data using the conflating script `conflate.py` using the following command, and answering the yes/no questions prompted by the tool.

```
$ python conflate.py -d "https://storage.googleapis.com/storage/v1/b/la-metro-bus-gtfs-q38215_archives_2021-12-19/o/ce70cfcd7457aea009f1183da2e4f32dbfb46e14.zip?alt=media" -D "Q22414" -S "Q939" 
```

The user could also add the stop manually using the Python interpreter since they are only looking to conflate the stop for Patsaouras Transit Plaza.

```
$ python 
>>> import gtfs_kit
>>> from operation.tools import add_stop
>>> la_metro_bus = gtfs_kit.read_feed("https://storage.googleapis.com/storage/v1/b/la-metro-bus-gtfs-q38215_archives_2021-12-19/o/ce70cfcd7457aea009f1183da2e4f32dbfb46e14.zip?alt=media", dist_units="km")
>>> la_metro_bus.stops.loc[la_metro_bus.stops.stop_name.str.contains("Patsaouras")]

      stop_id stop_code                           stop_name stop_desc   stop_lat    stop_lon stop_url  location_type parent_station  tpis_name
2017     3300      3300  Union Station Patsaouras Bus Plaza       NaN  34.053972 -118.232222      NaN            NaN            NaN        NaN
2018     3301      3301  Union Station Patsaouras Bus Plaza       NaN  34.053943 -118.232454      NaN            NaN            NaN        NaN
11329   30000     30000            Patsaouras Transit Plaza       NaN  34.055394 -118.233118      NaN            NaN            NaN        NaN

>>> la_metro_bus.stops.loc[la_metro_bus.stops.stop_id=="30000"]

      stop_id stop_code                 stop_name stop_desc   stop_lat    stop_lon stop_url  location_type parent_station  tpis_name
11329   30000     30000  Patsaouras Transit Plaza       NaN  34.055394 -118.233118      NaN            NaN            NaN        NaN

>>> add_stop(name="Patsaouras Transit Plaza", description="Patsaouras Transit Plaza", latitude=34.055394, longitude=-118.233118, ref_stop_id="30000", ref_dataset_id="Q22414", ref_source_id="Q939")

                                  id                      name  ...   longitude                                   referenced_stops
0  mdb_stop_34_055394_N_118_233118_E  Patsaouras Transit Plaza  ... -118.233118  [{'stop_id': '30000', 'dataset_id': 'Q22414', ...

```

This PR contains changes to:

- `stops.csv`, after the user has conflated their Patsaouaras Transit Plaza stop to the MDB Stops using the `add_stop()` operation. 

**Expected behavior:** 

A new MDB Stop should be created for the Patsaouras Transit Plaza stop in accordance with the LA Metro Bus dataset.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `pytest` to make sure you didn't break anything
- [x] Format the title like "<short description of fix and changes>" (for example - "Check for null value before using field")
- [x] Linked all relevant issues