### PR TITLE
Fixes #338: Explore approach to adding stops to the database (Patsaouras - LADOT Conflation)

### DIFF
--- a/stops.csv
+++ b/stops.csv
@@ -1,2 +1,2 @@
 id;name;description;latitude;longitude;referenced_stops
-mdb_stop_34_055394_N_118_233118_E;Patsaouras Transit Plaza;Patsaouras Transit Plaza;34.055394;-118.233118;[{'stop_id': '30000', 'dataset_id': 'Q22414', 'source_id': 'Q939'}]
+mdb_stop_34_055394_N_118_233118_E;Patsaouras Transit Plaza;Patsaouras Transit Plaza;34.055394;-118.233118;[{'stop_id': '30000', 'dataset_id': 'Q22414', 'source_id': 'Q939'}, {'stop_id': '432147', 'dataset_id': 'Q22415', 'source_id': 'Q19505'}]


### PR DESCRIPTION
**Summary:**

Fixes [#338](https://github.com/MobilityData/mobility-database-interface/issues/338): Explore approach to adding stops to the database (Patsaouras - LADOT Conflation)

This PR demonstrates what a LADOT user (developer) would submit to attach their Patsaouras Transit Plaza stop to the MDB Stop which appears to be the correct shared stop.

[Original scenario](https://docs.google.com/document/d/1ffvopKK3R2ckmwUWXtmCG93YSQOiTfO307a-hK798RE/edit#):
> (a) I’m LADOT and see a shared stop ID that references LA Metro’s stop 30000. I think **LA Metro’s stop is the same as my stop 432147. How do I represent them as the same place?**

Here, the LADOT stop for the Patsaouras Transit Plazea has been conflated with the MDB Stops. This would be done by a developer at LADOT. This will allow user to know that the MDB stop is shared for both providers.

To do this, the user can conflate their data using the conflating script `conflate.py` using the following command, and answering the yes/no questions prompted by the tool.

```
$ python conflate.py -d "https://storage.googleapis.com/storage/v1/b/ladot-feed-gtfs-q38122_archives_2022-01-13/o/7a7750c4946403d80a4d5f3377a0bb4780822039.zip?alt=media" -S "Q19505" -D "Q22415" -t 0.02 
```

This PR contains changes to:

- `stops.csv`, after the user has conflated their Patsaouaras Transit Plaza stop to the MDB Stops using the `attach_ref_stop()` operation through the `conflate.py` script. 

**Expected behavior:** 

The MDB stop for Patsaouras Transit Plaza should have 2 referenced stops, one for LA Metro Bus and another one for LADOT.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `pytest` to make sure you didn't break anything
- [x] Format the title like "<short description of fix and changes>" (for example - "Check for null value before using field")
- [x] Linked all relevant issues