### PR TITLE
Fixes #338: Explore approach to adding stops to the database (Patsaouras - LA Metro Bus Detach)

### DIFF
--- a/stops.csv
+++ b/stops.csv
@@ -1,2 +1,2 @@
 id;name;description;latitude;longitude;referenced_stops
-mdb_stop_34_055394_N_118_233118_E;Patsaouras Transit Plaza;Patsaouras Transit Plaza;34.055394;-118.233118;[{'stop_id': '30000', 'dataset_id': 'Q22414', 'source_id': 'Q939'}, {'stop_id': '432147', 'dataset_id': 'Q22415', 'source_id': 'Q19505'}]
+mdb_stop_34_055394_N_118_233118_E;Patsaouras Transit Plaza;Patsaouras Transit Plaza;34.055394;-118.233118;[{'stop_id': '30000', 'dataset_id': 'Q22414', 'source_id': 'Q939'}]

--- a/stops.csv
+++ b/stops.csv
@@ -1,2 +1,3 @@
 id;name;description;latitude;longitude;referenced_stops
 mdb_stop_34_055394_N_118_233118_E;Patsaouras Transit Plaza;Patsaouras Transit Plaza;34.055394;-118.233118;[{'stop_id': '30000', 'dataset_id': 'Q22414', 'source_id': 'Q939'}]
+mdb_stop_34_055294_N_118_233288_E;Patsaouras Transit Plaza - Bay 3;Patsaouras Transit Plaza - Bay 3;34.055294;-118.233288;[{'stop_id': '432147', 'dataset_id': 'Q22415', 'source_id': 'Q19505'}]


### PR DESCRIPTION
**Summary:**

Fixes [#338](https://github.com/MobilityData/mobility-database-interface/issues/338): Explore approach to adding stops to the database (Patsaouras - LA Metro Bus Detach)

This PR demonstrates what a LA Metro user (developer) would do to detach a referenced stop from LADOT that they think do not belong to the initial MDB Stop for Patsaouras Transit Plaza, and then create a new MDB Stop for that stop.

[Original scenario](https://docs.google.com/document/d/1ffvopKK3R2ckmwUWXtmCG93YSQOiTfO307a-hK798RE/edit#):
> (b) **If I’m LA Metro and I don’t think my stop 30000 is the same as either LADOT’s stop 432147 or 6715746. How do I detach my stop and create a new stop?**

Here, the LA Metro Bus stop for the Patsaouras Transit Plaza has been detaching the faulty stop and creating a new MDB stop for it. This would be done by a developer at LA Metro.

To do this, the user could detach and add the stop manually using the Python interpreter since they are looking to do the detach and add operations for only one stop.

```
$ python 
>>> import gtfs_kit
>>> from tools.operations import detach_ref_stop, add_stop
>>> detach_ref_stop(mdb_stop_id="mdb_stop_34_055394_N_118_233118_E", ref_stop_id="432147", ref_dataset_id="Q22415", ref_source_id="Q19505")

                                  id                      name  ...   longitude                                   referenced_stops
0  mdb_stop_34_055394_N_118_233118_E  Patsaouras Transit Plaza  ... -118.233118  [{'stop_id': '30000', 'dataset_id': 'Q22414', ...

>>> ladot = gtfs_kit.read_feed("https://storage.googleapis.com/storage/v1/b/ladot-feed-gtfs-q38122_archives_2022-01-13/o/7a7750c4946403d80a4d5f3377a0bb4780822039.zip?alt=media", dist_units="km")
>>> ladot.stops.loc[ladot.stops.stop_id=="432147"]
     stop_id stop_code                         stop_name stop_desc   stop_lat  ...  parent_station stop_timezone wheelchair_boarding  level_id platform_code
1550  432147      8945  Patsaouras Transit Plaza - Bay 3       NaN  34.055294  ...             NaN           NaN                   0       NaN           NaN

>>> add_stop(name="Patsaouras Transit Plaza - Bay 3", description="Patsaouras Transit Plaza - Bay 3", latitude=34.055294, longitude=-118.233288, ref_stop_id="432147", ref_dataset_id="Q22415", ref_source_id="Q19505")
                                  id                              name  ...   longitude                                   referenced_stops
0  mdb_stop_34_055394_N_118_233118_E          Patsaouras Transit Plaza  ... -118.233118  [{'stop_id': '30000', 'dataset_id': 'Q22414', ...
1  mdb_stop_34_055294_N_118_233288_E  Patsaouras Transit Plaza - Bay 3  ... -118.233288  [{'stop_id': '432147', 'dataset_id': 'Q22415',...

```

This PR contains changes to:

- `stops.csv`, after the user had detach the faulty referenced stop and add a new MDB stop using its information. 

**Expected behavior:** 

A new MDB Stop should be created for the Patsaouras Transit Plaza - Bay 3 stop in accordance with the LADOT dataset. The faulty referenced stop should be removed from the initial Patsaouras Transit Plaza MDB stop.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `pytest` to make sure you didn't break anything
- [x] Format the title like "<short description of fix and changes>" (for example - "Check for null value before using field")
- [x] Linked all relevant issues
- [ ] ~Include screenshot(s) showing how this pull request works and fixes the issue(s)~